### PR TITLE
Migrate to CircleCI 2 #80

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -61,6 +61,9 @@
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification" />
 
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
 - apache legacy library not required added to manifest to avoid crash with maps